### PR TITLE
Add struct and template

### DIFF
--- a/generator/template.go
+++ b/generator/template.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+    "io"
+    "text/template"
+)
+
+const (
+    tmpl = `
+    package generator
+
+    import (
+        "fmt"
+        "math/big"
+    )
+
+    type constantsStr struct {
+        C [][]string // compRoundConstants
+        S [][]string // sparseMatrix
+        M [][][]string // MDS matrix
+        P [][][]string // preSparseMatrix
+    }
+
+    var cs := constantsStr {
+        C: [][]string{
+            {{ range $element := .C }}
+            {
+                {{ range $subelement := $element}}
+                "{{ $subelement }}",
+                {{ end }}
+            },
+            {{ end }}
+        },
+        S: [][]string{
+            {{ range $element := .S }}
+            {
+                {{ range $subelement := $element}}
+                "{{ $subelement }}",
+                {{ end }}
+            },
+            {{ end }}
+        },
+        M: [][][]string{
+            {{ range $element := .M }}
+            {
+                {{ range $subelement := $element}}
+                {
+                    {{ range $subsub := $subelement}}
+                    "{{ $subsub }}",
+                    {{end}}
+                },
+                {{ end }}
+            },
+            {{ end }}
+        },
+        P: [][][]string{
+            {{ range $element := .P }}
+            {
+                {{ range $subelement := $element}}
+                {
+                    {{ range $subsub := $subelement}}
+                    "{{ $subsub }}",
+                    {{end}}
+                },
+                {{ end }}
+            },
+            {{ end }}
+        },
+    }
+    `
+)
+
+func GenerateTemplate(w io.Writer, constants *constantsStr) error {
+	t, err := template.New("t").Parse(tmpl)
+	if err != nil {
+		return err
+	}
+	return t.Execute(w, constants)
+}


### PR DESCRIPTION
Implements a template to produce formatted constant elements similar to https://github.com/mdehoog/gnark-circom-smt/blob/main/pkg/poseidon/constants.go#L72-L80

Note: on a run of 2 levels, the element `9600146bec7f4fd625ea9db1f247c6376f479f8fa4b34f1227f14ac41bc4cd3` seems to be repeated over and over -- likely due to a bug